### PR TITLE
refactor(cron): replace unsafe-looking unwrap with filter_map in get_next_wake_ms

### DIFF
--- a/core/src/cron/service.rs
+++ b/core/src/cron/service.rs
@@ -148,8 +148,7 @@ impl CronService {
         store
             .jobs
             .iter()
-            .filter(|j| j.enabled && j.state.next_run_at_ms.is_some())
-            .map(|j| j.state.next_run_at_ms.unwrap())
+            .filter_map(|j| if j.enabled { j.state.next_run_at_ms } else { None })
             .min()
     }
 


### PR DESCRIPTION
this would fix the #7  issue

**Fix**
Replaced the `.filter().map(|j| ...unwrap())` iterator chain with idiomatic `.filter_map()` to eliminate the unnecessary unwrap().