### PR TITLE
FEAT : Role-Based Permission System

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod cron;
 pub mod error;
 pub mod heartbeat;
 pub mod messages;
+pub mod permissions;
 pub mod provider;
 pub mod python_env;
 pub mod session;
@@ -32,6 +33,7 @@ pub use config::{
 pub use cron::{CronJob, CronPayload, CronSchedule, CronService};
 pub use error::*;
 pub use heartbeat::HeartbeatService;
+pub use permissions::{PermissionLevel, PermissionManager};
 pub use provider::{GroqTranscriptionProvider, TranscriptionProvider};
 pub use python_env::PythonEnv;
 pub use session::{

--- a/core/src/permissions.rs
+++ b/core/src/permissions.rs
@@ -1,0 +1,143 @@
+//! Role-based permission system for channels (currently Discord).
+//!
+//! This module centralizes permission tier logic so that role-to-permission
+//! mapping and multi-role priority handling live in one place.
+
+use crate::config::DiscordConfig;
+
+/// Permission levels in increasing order of privilege.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PermissionLevel {
+    Guest,
+    Member,
+    Admin,
+}
+
+impl PermissionLevel {}
+
+/// Alias used to mirror the `Action` parameter in the issue design.
+///
+/// For now, actions map directly to the minimum required `PermissionLevel`.
+pub type Action = PermissionLevel;
+
+/// Permission manager backed by configured admin and member role IDs.
+#[derive(Debug, Clone)]
+pub struct PermissionManager {
+    admin_roles: Vec<String>,
+    member_roles: Vec<String>,
+}
+
+impl PermissionManager {
+    /// Create a new permission manager from explicit role lists.
+    pub fn new(admin_roles: Vec<String>, member_roles: Vec<String>) -> Self {
+        Self {
+            admin_roles,
+            member_roles,
+        }
+    }
+
+    /// Create a permission manager from a `DiscordConfig`.
+    pub fn from_discord_config(config: &DiscordConfig) -> Self {
+        Self::new(config.admin_roles.clone(), config.member_roles.clone())
+    }
+
+    /// Compute the highest permission level for a user given their roles.
+    ///
+    /// - If the user has any admin role → `Admin`
+    /// - Else if the user has any member role → `Member`
+    /// - Else → `Guest`
+    pub fn level_for(&self, user_roles: &[String]) -> PermissionLevel {
+        if !self.admin_roles.is_empty()
+            && user_roles
+                .iter()
+                .any(|role| self.admin_roles.contains(role))
+        {
+            return PermissionLevel::Admin;
+        }
+
+        if !self.member_roles.is_empty()
+            && user_roles
+                .iter()
+                .any(|role| self.member_roles.contains(role))
+        {
+            return PermissionLevel::Member;
+        }
+
+        PermissionLevel::Guest
+    }
+
+    /// Check whether the user's roles satisfy the required permission level.
+    pub fn has_level(&self, user_roles: &[String], required: PermissionLevel) -> bool {
+        self.level_for(user_roles) >= required
+    }
+
+    /// Check permission for a given action (currently aliased to `PermissionLevel`).
+    pub fn check_permission(&self, user_roles: &[String], action: Action) -> bool {
+        self.has_level(user_roles, action)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roles(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn level_for_no_roles_is_guest() {
+        let mgr = PermissionManager::new(vec!["admin".into()], vec!["member".into()]);
+        assert_eq!(mgr.level_for(&roles(&[])), PermissionLevel::Guest);
+    }
+
+    #[test]
+    fn level_for_member_role_is_member() {
+        let mgr = PermissionManager::new(vec!["admin".into()], vec!["member".into()]);
+        assert_eq!(
+            mgr.level_for(&roles(&["member"])),
+            PermissionLevel::Member
+        );
+    }
+
+    #[test]
+    fn level_for_admin_role_is_admin() {
+        let mgr = PermissionManager::new(vec!["admin".into()], vec!["member".into()]);
+        assert_eq!(mgr.level_for(&roles(&["admin"])), PermissionLevel::Admin);
+    }
+
+    #[test]
+    fn level_for_both_admin_and_member_prefers_admin() {
+        let mgr = PermissionManager::new(vec!["admin".into()], vec!["member".into()]);
+        assert_eq!(
+            mgr.level_for(&roles(&["member", "admin"])),
+            PermissionLevel::Admin
+        );
+    }
+
+    #[test]
+    fn check_permission_respects_hierarchy() {
+        let mgr = PermissionManager::new(vec!["admin".into()], vec!["member".into()]);
+
+        let guest = roles(&[]);
+        let member = roles(&["member"]);
+        let admin = roles(&["admin"]);
+
+        // Guest
+        assert!(mgr.check_permission(&guest, PermissionLevel::Guest));
+        assert!(!mgr.check_permission(&guest, PermissionLevel::Member));
+        assert!(!mgr.check_permission(&guest, PermissionLevel::Admin));
+
+        // Member
+        assert!(mgr.check_permission(&member, PermissionLevel::Guest));
+        assert!(mgr.check_permission(&member, PermissionLevel::Member));
+        assert!(!mgr.check_permission(&member, PermissionLevel::Admin));
+
+        // Admin
+        assert!(mgr.check_permission(&admin, PermissionLevel::Guest));
+        assert!(mgr.check_permission(&admin, PermissionLevel::Member));
+        assert!(mgr.check_permission(&admin, PermissionLevel::Admin));
+    }
+}
+
+


### PR DESCRIPTION
## 📋 Summary

This PR introduces a centralized **role-based permission system** for Discord in mofaclaw and wires it into the existing Discord channel implementation. It formalizes the Admin/Member/Guest tiers described in the spec so that sensitive GitHub and release actions consistently respect Discord role configuration.

## 🔗 Related Issues

Closes #21 


---

## 🧠 Context

mofaclaw already exposed `admin_roles` and `member_roles` in `DiscordConfig`, and the Discord channel had scattered helper methods (`is_admin`, `is_member`, `is_guest`) plus per-command checks. However, there was no single, reusable permission module implementing the three-tier system from issue #21, nor centralized handling of multi-role precedence. This change adds a dedicated permission module and routes Discord’s permission checks through it, making behavior explicit, testable, and ready for future reuse by other modules.

---

## 🛠️ Changes

- **Added** a new `core::permissions` module:
  - `PermissionLevel` enum (`Guest`, `Member`, `Admin`) with ordering semantics.
  - `PermissionManager` struct backed by `DiscordConfig` role lists, including:
    - `level_for(&[String]) -> PermissionLevel` (Admin > Member > Guest).
    - `has_level(&[String], PermissionLevel) -> bool`.
    - `check_permission(&[String], Action)` where `Action` is currently aliased to `PermissionLevel`.
- **Exported** `PermissionLevel` and `PermissionManager` from `core::lib` so they are available to channels and other code.
- **Updated** `DiscordChannel` in `core/src/channels/discord/mod.rs` to:
  - Construct a `PermissionManager` from `DiscordConfig`.
  - Implement `is_admin` and `is_member` in terms of `PermissionManager::has_level(…, PermissionLevel::Admin/Member)`.
  - Keep `is_guest` behavior unchanged (everyone is a guest by default).
- **Preserved** existing permission semantics for all Discord slash commands:
  - Admin-only actions (e.g. `/pr merge`, `/release delete`, `/issue assign`, `/skill create`) now delegate to the centralized permission manager.
  - Member-only and guest actions keep their behavior, but via the new abstraction.

---

## 🧪 How you Tested

1. Ran `cargo test -p mofaclaw-core` to validate the core crate after introducing the new module and integration.
2. Verified that the new `permissions` module compiles cleanly and has no lints (via internal lints tooling on `permissions.rs` and `discord/mod.rs`).
3. Manually validated Discord startup and role mapping by configuring `admin_roles`/`member_roles` in `~/.mofaclaw/config.json` and confirming:
   - Admin-only commands are gated by admin roles.
   - Member-only commands are allowed for both Member and Admin.
   - Guest-only operations remain accessible to all users.

> Note: There are two pre-existing failing tests in `mofaclaw-core` (`test_active_subagent_display_label` and `test_is_heartbeat_empty`) unrelated to this change; they reproduce on `main` as well and were not modified here.

---

## 📸 Screenshots / Logs (if applicable)

### For Admin-Role:
<img width="669" height="414" alt="admin" src="https://github.com/user-attachments/assets/dd4cca90-03f3-47e8-9062-37b6360d7f14" />

---
### For Member-Role:
<img width="618" height="744" alt="member" src="https://github.com/user-attachments/assets/c797c545-2157-457f-bf30-6cc3d2c4400f" />


---
### For Guest-Role:
<img width="700" height="617" alt="Guest" src="https://github.com/user-attachments/assets/00abc428-c0b8-4e9f-a517-0ebc32622088" />


---

## ⚠️ Breaking Changes

- [x] No breaking changes  
- [ ] Breaking change (describe below)

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
  
### Testing
- [x] Tests added/updated (new permission logic is covered by compilation and existing Discord command paths; a follow-up can add focused unit tests on `PermissionManager` if desired)
- [x] `cargo test` passes locally without any error  
  - Core tests run; two known unrelated tests fail on `main` as well (see notes above).

### PR Hygiene
- [x] PR is small and focused (one logical change: centralized Discord RBAC)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

- No migrations required.
- Existing `DiscordConfig` keys (`admin_roles`, `member_roles`) are reused; no config shape changes.
- After deploy, behavior respects the same roles as before, but the mapping is now centralized and easier to reason about.

---

## 🧩 Additional Notes for Reviewers

- The `Action` type in `PermissionManager::check_permission` is currently an alias for `PermissionLevel`. This keeps the API aligned with the original issue design while leaving room to evolve `Action` into a richer enum in future GitHub/Discord permission work.
- All existing user-facing “permission denied” messages remain unchanged; only the internal decision logic has moved into the new permission module.

