### PR TITLE
feat: implement OpenAI-compatible HTTP API gateway on port 18790

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,6 +35,11 @@ infer = "0.15"
 base64 = "0.22"
 glob = "0.3"
 
+# http server for REST API gateway
+axum = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
+
 # telegram
 teloxide = { workspace = true }
 

--- a/core/src/gateway/mod.rs
+++ b/core/src/gateway/mod.rs
@@ -1,0 +1,304 @@
+//! HTTP REST API Gateway for mofaclaw
+//!
+//! Exposes an OpenAI-compatible API on port 18790 (default) so any tool that
+//! speaks the OpenAI chat-completions protocol can talk to the mofaclaw agent.
+//!
+//! # Endpoints
+//!
+//! | Method | Path                      | Description                     |
+//! |--------|---------------------------|---------------------------------|
+//! | GET    | `/`                       | Welcome / info                  |
+//! | GET    | `/health`                 | Health check (returns 200 OK)   |
+//! | GET    | `/v1/models`              | List available models           |
+//! | POST   | `/v1/chat/completions`    | Chat (streaming and non-stream) |
+//!
+//! # Quick start
+//! ```bash
+//! curl http://localhost:18790/v1/chat/completions \
+//!   -H "Content-Type: application/json" \
+//!   -d '{"model":"mofaclaw","messages":[{"role":"user","content":"Hello!"}]}'
+//! ```
+
+pub mod types;
+
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    net::SocketAddr,
+    sync::Arc,
+    time::Duration,
+};
+
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    response::{
+        IntoResponse, Response,
+        sse::{Event, KeepAlive, Sse},
+    },
+    routing::{get, post},
+};
+use futures_util::stream;
+use tokio::sync::{Mutex, oneshot};
+use tower_http::cors::CorsLayer;
+use tracing::{debug, error, info, warn};
+use uuid::Uuid;
+
+use crate::{
+    MessageBus,
+    messages::InboundMessage,
+};
+
+use types::{
+    ApiError, ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ModelList,
+};
+
+// ─────────────────────────── Pending-request map ──────────────────────────
+
+/// In-flight HTTP requests waiting for an agent response.
+///
+/// Key: `chat_id` used for the InboundMessage (unique per request unless the
+///      caller supplies a `conversation_id`).
+/// Value: oneshot sender – fires when the agent publishes an outbound reply.
+type PendingMap = Arc<Mutex<HashMap<String, oneshot::Sender<String>>>>;
+
+// ─────────────────────────── Shared state ─────────────────────────────────
+
+#[derive(Clone)]
+pub struct GatewayState {
+    bus: MessageBus,
+    pending: PendingMap,
+    model: String,
+}
+
+// ─────────────────────────── Server ───────────────────────────────────────
+
+/// The HTTP gateway server.
+pub struct GatewayServer {
+    bus: MessageBus,
+    host: String,
+    port: u16,
+    model: String,
+}
+
+impl GatewayServer {
+    pub fn new(bus: MessageBus, host: impl Into<String>, port: u16, model: impl Into<String>) -> Self {
+        Self {
+            bus,
+            host: host.into(),
+            port,
+            model: model.into(),
+        }
+    }
+
+    /// Start the HTTP server.  Runs until the process is stopped.
+    pub async fn run(self) -> anyhow::Result<()> {
+        let pending: PendingMap = Arc::new(Mutex::new(HashMap::new()));
+
+        // Spawn the outbound-dispatch background task.
+        // It subscribes to the message bus and resolves pending HTTP requests.
+        let pending_for_dispatch = pending.clone();
+        let mut outbound_rx = self.bus.subscribe_outbound();
+        tokio::spawn(async move {
+            loop {
+                match outbound_rx.recv().await {
+                    Ok(msg) => {
+                        if msg.channel != "api" {
+                            continue;
+                        }
+                        debug!("API gateway received outbound for chat_id={}", msg.chat_id);
+                        let mut map = pending_for_dispatch.lock().await;
+                        if let Some(tx) = map.remove(&msg.chat_id) {
+                            let _ = tx.send(msg.content);
+                        } else {
+                            warn!("No pending request for chat_id={}", msg.chat_id);
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        warn!("API gateway outbound receiver lagged by {} messages", n);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        info!("API gateway outbound bus closed – stopping dispatch task");
+                        break;
+                    }
+                }
+            }
+        });
+
+        let state = GatewayState {
+            bus: self.bus,
+            pending,
+            model: self.model,
+        };
+
+        let app = Router::new()
+            .route("/", get(handle_root))
+            .route("/health", get(handle_health))
+            .route("/v1/models", get(handle_models))
+            .route("/v1/chat/completions", post(handle_chat_completions))
+            .layer(CorsLayer::permissive())
+            .with_state(state);
+
+        let addr: SocketAddr = format!("{}:{}", self.host, self.port).parse()?;
+        info!("HTTP API gateway listening on http://{}", addr);
+        println!("HTTP API: http://{}  (OpenAI-compatible)", addr);
+
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        axum::serve(listener, app).await?;
+        Ok(())
+    }
+}
+
+// ─────────────────────────── Handlers ─────────────────────────────────────
+
+async fn handle_root() -> impl IntoResponse {
+    Json(serde_json::json!({
+        "name": "mofaclaw",
+        "version": env!("CARGO_PKG_VERSION"),
+        "description": "Mofaclaw AI assistant – OpenAI-compatible HTTP API",
+        "endpoints": {
+            "GET  /health":                 "Health check",
+            "GET  /v1/models":              "List models",
+            "POST /v1/chat/completions":    "Chat (stream=false|true)"
+        },
+        "docs": "https://github.com/mofa-org/mofaclaw"
+    }))
+}
+
+async fn handle_health() -> impl IntoResponse {
+    Json(serde_json::json!({"status": "ok"}))
+}
+
+async fn handle_models(State(state): State<GatewayState>) -> impl IntoResponse {
+    Json(ModelList::mofaclaw_models(&state.model))
+}
+
+async fn handle_chat_completions(
+    State(state): State<GatewayState>,
+    Json(req): Json<ChatCompletionRequest>,
+) -> Response {
+    // Determine session / chat_id
+    let chat_id = req
+        .conversation_id
+        .clone()
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+    // Extract the latest user message (the session carries prior history)
+    let user_content = req
+        .messages
+        .iter()
+        .rev()
+        .find(|m| m.role == "user")
+        .map(|m| m.content.clone())
+        .unwrap_or_default();
+
+    if user_content.is_empty() {
+        let status = StatusCode::BAD_REQUEST;
+        let body = Json(ApiError::internal("No user message found in request"));
+        return (status, body).into_response();
+    }
+
+    // Register pending request BEFORE publishing so the reply isn't missed
+    let (tx, rx) = oneshot::channel::<String>();
+    {
+        let mut map = state.pending.lock().await;
+        map.insert(chat_id.clone(), tx);
+    }
+
+    // Publish to the agent via the message bus
+    let inbound = InboundMessage::new("api", "api-user", &chat_id, &user_content);
+    if let Err(e) = state.bus.publish_inbound(inbound).await {
+        error!("Failed to publish inbound message: {}", e);
+        let mut map = state.pending.lock().await;
+        map.remove(&chat_id);
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiError::internal(format!("Bus error: {e}"))),
+        )
+            .into_response();
+    }
+
+    // Wait for the agent response (2-minute hard timeout)
+    let response_text = match tokio::time::timeout(Duration::from_secs(120), rx).await {
+        Ok(Ok(text)) => text,
+        Ok(Err(_)) => {
+            // sender dropped without sending
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiError::internal("Agent response channel closed unexpectedly")),
+            )
+                .into_response();
+        }
+        Err(_) => {
+            // Timed out – clean up the pending entry
+            let mut map = state.pending.lock().await;
+            map.remove(&chat_id);
+            return (StatusCode::GATEWAY_TIMEOUT, Json(ApiError::timeout())).into_response();
+        }
+    };
+
+    let completion_id = format!("chatcmpl-{}", Uuid::new_v4().simple());
+
+    if req.stream {
+        // ── Streaming path: SSE with OpenAI-format chunks ──────────────────
+        // The agent processes in one shot, so we stream the response
+        // word-by-word to give clients the streaming experience.
+        let model = state.model.clone();
+        let id_for_stream = completion_id.clone();
+
+        let words: Vec<String> = response_text
+            .split_inclusive(' ')
+            .map(|s| s.to_string())
+            .collect();
+
+        let event_stream = {
+            let model_role = model.clone();
+            let id_role = id_for_stream.clone();
+            let model_words = model.clone();
+            let id_words = id_for_stream.clone();
+            let model_stop = model.clone();
+            let id_stop = id_for_stream.clone();
+
+            // Build a Vec of SSE events: role → words → stop
+            let mut events: Vec<Result<Event, Infallible>> = Vec::new();
+
+            // Role event
+            let role_chunk = ChatCompletionChunk::role_chunk(&id_role, &model_role);
+            if let Ok(data) = serde_json::to_string(&role_chunk) {
+                events.push(Ok(Event::default().data(data)));
+            }
+
+            // Word events
+            for word in words {
+                let chunk = ChatCompletionChunk::content_chunk(&id_words, &model_words, word);
+                if let Ok(data) = serde_json::to_string(&chunk) {
+                    events.push(Ok(Event::default().data(data)));
+                }
+            }
+
+            // Stop event
+            let stop_chunk = ChatCompletionChunk::stop_chunk(&id_stop, &model_stop);
+            if let Ok(data) = serde_json::to_string(&stop_chunk) {
+                events.push(Ok(Event::default().data(data)));
+            }
+
+            // Terminator
+            events.push(Ok(Event::default().data("[DONE]")));
+
+            stream::iter(events)
+        };
+
+        Sse::new(event_stream)
+            .keep_alive(KeepAlive::default())
+            .into_response()
+    } else {
+        // ── Non-streaming path ──────────────────────────────────────────────
+        Json(ChatCompletionResponse::new(
+            completion_id,
+            &state.model,
+            response_text,
+        ))
+        .into_response()
+    }
+}

--- a/core/src/gateway/types.rs
+++ b/core/src/gateway/types.rs
@@ -1,0 +1,246 @@
+//! OpenAI-compatible API types for the mofaclaw HTTP gateway
+//!
+//! These types allow any OpenAI-compatible client (curl, Python openai SDK,
+//! LangChain, etc.) to talk to mofaclaw using the familiar `/v1/chat/completions` endpoint.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+// ─────────────────────────── Request types ────────────────────────────────
+
+/// A single message in the conversation history
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessage {
+    /// "system", "user", or "assistant"
+    pub role: String,
+    /// Message text content
+    pub content: String,
+}
+
+/// POST /v1/chat/completions request body
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChatCompletionRequest {
+    /// Model name (ignored – mofaclaw uses its configured model)
+    #[serde(default = "default_model")]
+    pub model: String,
+    /// Conversation messages
+    pub messages: Vec<ChatMessage>,
+    /// Whether to stream the response via SSE
+    #[serde(default)]
+    pub stream: bool,
+    /// Optional caller-supplied conversation ID for multi-turn sessions.
+    /// If omitted a new UUID is generated for each request.
+    #[serde(default)]
+    pub conversation_id: Option<String>,
+}
+
+fn default_model() -> String {
+    "mofaclaw".to_string()
+}
+
+// ─────────────────────────── Response types ───────────────────────────────
+
+/// Non-streaming chat completion response  (mirrors OpenAI schema)
+#[derive(Debug, Serialize)]
+pub struct ChatCompletionResponse {
+    pub id: String,
+    pub object: String,
+    pub created: i64,
+    pub model: String,
+    pub choices: Vec<Choice>,
+    pub usage: Usage,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Choice {
+    pub index: u32,
+    pub message: ChatMessage,
+    pub finish_reason: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Usage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+impl ChatCompletionResponse {
+    pub fn new(id: impl Into<String>, model: impl Into<String>, content: impl Into<String>) -> Self {
+        let content = content.into();
+        let completion_tokens = content.split_whitespace().count() as u32;
+        Self {
+            id: id.into(),
+            object: "chat.completion".to_string(),
+            created: Utc::now().timestamp(),
+            model: model.into(),
+            choices: vec![Choice {
+                index: 0,
+                message: ChatMessage {
+                    role: "assistant".to_string(),
+                    content: content.clone(),
+                },
+                finish_reason: "stop".to_string(),
+            }],
+            usage: Usage {
+                prompt_tokens: 0,
+                completion_tokens,
+                total_tokens: completion_tokens,
+            },
+        }
+    }
+}
+
+// ─────────────────────── Streaming chunk types ────────────────────────────
+
+/// One SSE chunk for streaming responses
+#[derive(Debug, Serialize)]
+pub struct ChatCompletionChunk {
+    pub id: String,
+    pub object: String,
+    pub created: i64,
+    pub model: String,
+    pub choices: Vec<ChunkChoice>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChunkChoice {
+    pub index: u32,
+    pub delta: Delta,
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Delta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+}
+
+impl ChatCompletionChunk {
+    /// First chunk – sets role, no content yet
+    pub fn role_chunk(id: impl Into<String>, model: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            object: "chat.completion.chunk".to_string(),
+            created: Utc::now().timestamp(),
+            model: model.into(),
+            choices: vec![ChunkChoice {
+                index: 0,
+                delta: Delta {
+                    role: Some("assistant".to_string()),
+                    content: None,
+                },
+                finish_reason: None,
+            }],
+        }
+    }
+
+    /// Content chunk
+    pub fn content_chunk(
+        id: impl Into<String>,
+        model: impl Into<String>,
+        content: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            object: "chat.completion.chunk".to_string(),
+            created: Utc::now().timestamp(),
+            model: model.into(),
+            choices: vec![ChunkChoice {
+                index: 0,
+                delta: Delta {
+                    role: None,
+                    content: Some(content.into()),
+                },
+                finish_reason: None,
+            }],
+        }
+    }
+
+    /// Final chunk – signals stream end
+    pub fn stop_chunk(id: impl Into<String>, model: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            object: "chat.completion.chunk".to_string(),
+            created: Utc::now().timestamp(),
+            model: model.into(),
+            choices: vec![ChunkChoice {
+                index: 0,
+                delta: Delta {
+                    role: None,
+                    content: None,
+                },
+                finish_reason: Some("stop".to_string()),
+            }],
+        }
+    }
+}
+
+// ─────────────────────────── Models endpoint ──────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct ModelList {
+    pub object: String,
+    pub data: Vec<ModelInfo>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ModelInfo {
+    pub id: String,
+    pub object: String,
+    pub created: i64,
+    pub owned_by: String,
+}
+
+impl ModelList {
+    pub fn mofaclaw_models(model: impl Into<String>) -> Self {
+        let model = model.into();
+        Self {
+            object: "list".to_string(),
+            data: vec![ModelInfo {
+                id: model,
+                object: "model".to_string(),
+                created: 1_700_000_000,
+                owned_by: "mofaclaw".to_string(),
+            }],
+        }
+    }
+}
+
+// ─────────────────────────── Error response ───────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct ApiError {
+    pub error: ApiErrorBody,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ApiErrorBody {
+    pub message: String,
+    pub r#type: String,
+    pub code: Option<String>,
+}
+
+impl ApiError {
+    pub fn internal(msg: impl Into<String>) -> Self {
+        Self {
+            error: ApiErrorBody {
+                message: msg.into(),
+                r#type: "internal_error".to_string(),
+                code: None,
+            },
+        }
+    }
+
+    pub fn timeout() -> Self {
+        Self {
+            error: ApiErrorBody {
+                message: "Request timed out waiting for agent response".to_string(),
+                r#type: "timeout".to_string(),
+                code: Some("timeout".to_string()),
+            },
+        }
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod channels;
 pub mod config;
 pub mod cron;
 pub mod error;
+pub mod gateway;
 pub mod heartbeat;
 pub mod messages;
 pub mod permissions;
@@ -32,6 +33,7 @@ pub use config::{
     get_config_dir, get_config_path, get_data_dir, get_workspace_path, load_config, save_config,
 };
 pub use cron::{CronJob, CronPayload, CronSchedule, CronService};
+pub use gateway::GatewayServer;
 pub use error::*;
 pub use heartbeat::HeartbeatService;
 pub use permissions::{PermissionLevel, PermissionManager};


### PR DESCRIPTION
# feat: implement OpenAI-compatible HTTP API gateway on port 18790

## Summary

The `mofaclaw gateway` command exposed port 18790 in Docker and had a `GatewayConfig` struct with `host` and `port` fields, but nothing ever bound to that port. The axum, tower, and tower-http crates were already declared as workspace dependencies but unused. This PR closes that gap by implementing a fully functional OpenAI-compatible REST API server that starts alongside the existing agent loop and channel manager when you run `mofaclaw gateway`.

## What Changed

**core/src/gateway/types.rs** — New file containing all OpenAI-compatible data structures. This includes `ChatCompletionRequest` (with an extra optional `conversation_id` field for multi-turn sessions), `ChatCompletionResponse`, `ChatCompletionChunk` for streaming, `ModelList`, and `ApiError`. All structs mirror the OpenAI wire format so existing clients work without modification.

**core/src/gateway/mod.rs** — New file containing `GatewayServer`. It starts an axum HTTP server and registers four routes. A background tokio task subscribes to the message bus outbound channel and routes replies back to the waiting HTTP handler using oneshot channels stored in a `PendingMap`. The streaming path word-tokenizes the full agent response and emits it as a sequence of SSE chunks so clients that set `stream: true` get the familiar token-by-token experience.

**core/Cargo.toml** — Added axum, tower, and tower-http as dependencies (all already declared at the workspace level, so no version pinning needed here).

**core/src/lib.rs** — Added `pub mod gateway` and re-exported `GatewayServer`.

**cli/src/main.rs** — Imported `GatewayServer` and added `http_server.run()` as a third arm of the `tokio::select!` block in `command_gateway`, so the HTTP server runs concurrently with the agent loop and channel manager under a shared tokio runtime.

## API Reference

GET  /                       info and endpoint list
GET  /health                 returns {"status":"ok"}
GET  /v1/models              OpenAI model list response
POST /v1/chat/completions    chat, supports stream true or false



## How Request Correlation Works

Each HTTP request generates a UUID used as `chat_id`. Before publishing to the message bus, the handler inserts a `oneshot::Sender<String>` into a shared `PendingMap` keyed by that `chat_id`. The background dispatch task listens on the broadcast outbound channel and, whenever it sees a message with `channel == "api"`, pops the matching sender from the map and fires it. The HTTP handler then receives on the oneshot receiver with a 120-second timeout before formatting the OpenAI response. Multi-turn sessions work by passing a stable `conversation_id` in the request body, which reuses the same session key across calls.

## Example Usage

```bash
# Non-streaming
curl http://localhost:18790/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"mofaclaw","messages":[{"role":"user","content":"Hello!"}]}'

# Streaming
curl -N http://localhost:18790/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"mofaclaw","stream":true,"messages":[{"role":"user","content":"Hello!"}]}'

# Multi-turn (reuse conversation_id across requests)
curl http://localhost:18790/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"mofaclaw","conversation_id":"my-session","messages":[{"role":"user","content":"Follow up"}]}'
```

Any OpenAI-compatible client (Python openai SDK, LangChain, LlamaIndex, Continue, etc.) can point its `base_url` at `http://localhost:18790/v1` and use mofaclaw as a drop-in model with full tool and memory capabilities.