### PR TITLE
FEAT: Add Github Webhook Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1117,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1648,6 +1701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hf-hub"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,6 +1728,15 @@ dependencies = [
  "tokio",
  "ureq",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1827,6 +1895,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2454,6 +2523,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,6 +2788,7 @@ name = "mofaclaw"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "axum",
  "chrono",
  "clap",
  "console",
@@ -2722,6 +2798,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2740,6 +2818,8 @@ dependencies = [
  "dotenvy",
  "futures-util",
  "glob",
+ "hex",
+ "hmac",
  "html-escape",
  "html2md",
  "infer 0.15.0",
@@ -2752,6 +2832,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serenity",
+ "sha2",
  "teloxide",
  "tempfile",
  "thiserror 2.0.18",
@@ -4085,6 +4166,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5004,6 +5096,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -291,6 +291,14 @@ Config file: `~/.mofaclaw/config.json`
     "host": "0.0.0.0",
     "port": 18790
   },
+  "webhooks": {
+    "github": {
+      "enabled": false,
+      "secret": "",
+      "discord_channel_ids": [],
+      "events": ["pull_request", "issues", "push", "workflow_run", "release"]
+    }
+  },
   "tools": {
     "web": {
       "search": {
@@ -305,6 +313,35 @@ Config file: `~/.mofaclaw/config.json`
 }
 ```
 
+</details>
+
+<details>
+<summary><b>GitHub Webhook → Discord notifications</b></summary>
+
+When the gateway is running, you can receive GitHub repo events (PR, issues, push, CI, release) as Discord embeds.
+
+1. **Configure** in `~/.mofaclaw/config.json`:
+
+```json
+"webhooks": {
+  "github": {
+    "enabled": true,
+    "secret": "YOUR_WEBHOOK_SECRET",
+    "discord_channel_ids": ["DISCORD_CHANNEL_ID"],
+    "events": ["pull_request", "issues", "push", "workflow_run", "release"]
+  }
+}
+```
+
+2. **In GitHub**: Repo → Settings → Webhooks → Add webhook  
+   - **Payload URL:** `http(s)://YOUR_HOST:18790/webhooks/github`  
+   - **Content type:** application/json  
+   - **Secret:** same as `webhooks.github.secret`  
+   - **Events:** choose the events you want (or "Send everything")
+
+3. Ensure the **Discord** channel is enabled and the bot has access to the channel IDs in `discord_channel_ids`.
+
+**Full step-by-step:** see [docs/DISCORD_WEBHOOK_SETUP.md](docs/DISCORD_WEBHOOK_SETUP.md) for Discord bot creation, config, running the gateway, and testing the webhook.
 </details>
 
 ## CLI Reference

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,6 +28,12 @@ dirs = "5.0"
 
 # Date/time
 chrono = { workspace = true }
+
+# HTTP server for webhooks
+axum = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
+
 #  local path with latest framework updates
 #mofa-sdk = { path = "/Users/lijing/CodeProjects/mofa/crates/mofa-sdk" }
 mofa-sdk = "0.1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,6 +34,9 @@ tempfile = "3.14"
 infer = "0.15"
 base64 = "0.22"
 glob = "0.3"
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
 
 # telegram
 teloxide = { workspace = true }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -281,6 +281,30 @@ pub struct ProvidersConfig {
     pub groq: ProviderConfig,
 }
 
+/// GitHub webhook configuration (for pushing repo events to Discord)
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GitHubWebhookConfig {
+    /// Whether GitHub webhook receiver is enabled
+    #[serde(default)]
+    pub enabled: bool,
+    /// Webhook secret for X-Hub-Signature-256 verification (optional but recommended)
+    #[serde(default)]
+    pub secret: String,
+    /// Discord channel IDs to post notifications to (e.g. ["1234567890123456789"])
+    #[serde(default)]
+    pub discord_channel_ids: Vec<String>,
+    /// Event types to forward (empty = all supported). e.g. ["pull_request", "issues", "push", "workflow_run", "release"]
+    #[serde(default)]
+    pub events: Vec<String>,
+}
+
+/// Webhooks configuration
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WebhooksConfig {
+    #[serde(default)]
+    pub github: GitHubWebhookConfig,
+}
+
 /// Gateway/server configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GatewayConfig {
@@ -372,6 +396,9 @@ pub struct Config {
     /// RBAC configuration
     #[serde(default)]
     pub rbac: Option<RbacConfig>,
+    /// Webhooks (e.g. GitHub → Discord notifications)
+    #[serde(default)]
+    pub webhooks: WebhooksConfig,
 }
 
 impl Config {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod python_env;
 pub mod session;
 pub mod tools;
 pub mod types;
+pub mod webhooks;
 
 // Re-exports for convenience
 pub use agent::{AgentLoop, ContextBuilder, SubagentManager};
@@ -27,9 +28,10 @@ pub use bus::{InboundMessage, MessageBus, OutboundMessage};
 pub use channels::{Channel, ChannelManager, DingTalkChannel, FeishuChannel, TelegramChannel};
 pub use config::{
     AgentDefaults, AgentsConfig, ChannelsConfig, Config, DingTalkConfig, FeishuConfig,
-    GatewayConfig, ProviderConfig, ProvidersConfig, TelegramConfig, ToolsConfig,
-    TranscriptionConfig, WebSearchConfig, WebToolsConfig, WhatsAppConfig, default_config,
-    get_config_dir, get_config_path, get_data_dir, get_workspace_path, load_config, save_config,
+    GatewayConfig, GitHubWebhookConfig, ProviderConfig, ProvidersConfig, TelegramConfig,
+    ToolsConfig, TranscriptionConfig, WebSearchConfig, WebToolsConfig, WebhooksConfig,
+    WhatsAppConfig, default_config, get_config_dir, get_config_path, get_data_dir,
+    get_workspace_path, load_config, save_config,
 };
 pub use cron::{CronJob, CronPayload, CronSchedule, CronService};
 pub use error::*;
@@ -43,3 +45,4 @@ pub use session::{
 };
 pub use tools::ToolRegistry;
 pub use types::*;
+pub use webhooks::{build_discord_notifications, verify_signature};

--- a/core/src/webhooks/github.rs
+++ b/core/src/webhooks/github.rs
@@ -1,0 +1,342 @@
+//! GitHub webhook payload parsing and Discord notification formatting.
+//!
+//! Supports: pull_request, issues, push, workflow_run, release.
+
+use crate::config::GitHubWebhookConfig;
+use crate::messages::OutboundMessage;
+use serde::Deserialize;
+use std::collections::HashMap;
+use tracing::debug;
+
+/// Verify GitHub webhook signature (X-Hub-Signature-256: sha256=...).
+pub fn verify_signature(secret: &str, signature_header: Option<&str>, body: &[u8]) -> bool {
+    let Some(sig) = signature_header else {
+        return secret.is_empty();
+    };
+    let sig = sig.trim();
+    if sig.len() < 7 || !sig.get(..7).map_or(false, |s| s.eq_ignore_ascii_case("sha256=")) {
+        return false;
+    }
+    let expected = match hex::decode(sig.get(7..).unwrap_or("")) {
+        Ok(b) => b,
+        Err(_) => return false,
+    };
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    type HmacSha256 = Hmac<Sha256>;
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key size");
+    mac.update(body);
+    let result = mac.finalize();
+    let computed = result.into_bytes();
+    if computed.len() != expected.len() {
+        return false;
+    }
+    computed
+        .iter()
+        .zip(expected.iter())
+        .all(|(a, b)| a == b)
+}
+
+/// Minimal repo info present in all payloads
+#[derive(Debug, Deserialize)]
+pub struct RepoInfo {
+    pub full_name: Option<String>,
+    pub html_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UserInfo {
+    pub login: Option<String>,
+    pub html_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PullRequestPayload {
+    pub action: Option<String>,
+    pub number: Option<u64>,
+    pub pull_request: Option<PullRequestInner>,
+    pub repository: Option<RepoInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PullRequestInner {
+    pub title: Option<String>,
+    pub html_url: Option<String>,
+    pub state: Option<String>,
+    pub merged: Option<bool>,
+    pub user: Option<UserInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct IssuesPayload {
+    pub action: Option<String>,
+    pub issue: Option<IssueInner>,
+    pub repository: Option<RepoInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct IssueInner {
+    pub number: Option<u64>,
+    pub title: Option<String>,
+    pub html_url: Option<String>,
+    pub state: Option<String>,
+    pub user: Option<UserInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PushPayload {
+    pub r#ref: Option<String>,
+    pub repository: Option<RepoInfo>,
+    pub pusher: Option<PusherInfo>,
+    pub compare: Option<String>,
+    pub commits: Option<Vec<CommitInfo>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PusherInfo {
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CommitInfo {
+    pub message: Option<String>,
+    pub id: Option<String>,
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WorkflowRunPayload {
+    pub action: Option<String>,
+    pub workflow_run: Option<WorkflowRunInner>,
+    pub repository: Option<RepoInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WorkflowRunInner {
+    pub name: Option<String>,
+    pub status: Option<String>,
+    pub conclusion: Option<String>,
+    pub html_url: Option<String>,
+    pub repository: Option<RepoInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReleasePayload {
+    pub action: Option<String>,
+    pub release: Option<ReleaseInner>,
+    pub repository: Option<RepoInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ReleaseInner {
+    pub name: Option<String>,
+    pub tag_name: Option<String>,
+    pub html_url: Option<String>,
+    pub author: Option<UserInfo>,
+}
+
+/// Discord embed color constants (decimal)
+const COLOR_PR_OPEN: u32 = 0x2ecc71;   // green
+const COLOR_PR_MERGED: u32 = 0x9b59b6; // purple
+const COLOR_PR_CLOSED: u32 = 0xe74c3c; // red
+const COLOR_ISSUE: u32 = 0x3498db;    // blue
+const COLOR_PUSH: u32 = 0x1abc9c;     // teal
+const COLOR_CI_SUCCESS: u32 = 0x2ecc71;
+const COLOR_CI_FAILURE: u32 = 0xe74c3c;
+const COLOR_CI_NEUTRAL: u32 = 0x95a5a6;
+const COLOR_RELEASE: u32 = 0xf1c40f;  // yellow
+
+fn embed_metadata(title: String, description: String, url: Option<String>, color: u32) -> HashMap<String, serde_json::Value> {
+    let mut m = HashMap::new();
+    m.insert("embed_title".to_string(), serde_json::json!(title));
+    m.insert("embed_description".to_string(), serde_json::json!(description));
+    m.insert("embed_color".to_string(), serde_json::json!(color as i32));
+    if let Some(u) = url {
+        m.insert("embed_url".to_string(), serde_json::json!(u));
+    }
+    m
+}
+
+/// Build one or more OutboundMessages for Discord from a GitHub webhook event.
+/// Returns empty vec if event is filtered out or parsing fails.
+pub fn build_discord_notifications(
+    config: &GitHubWebhookConfig,
+    event_type: &str,
+    body: &[u8],
+) -> Vec<OutboundMessage> {
+    if config.discord_channel_ids.is_empty() {
+        return vec![];
+    }
+    if !config.events.is_empty() && !config.events.iter().any(|e| e == event_type) {
+        debug!("GitHub webhook event {} filtered out by config", event_type);
+        return vec![];
+    }
+
+    let (content, metadata) = match event_type {
+        "pull_request" => format_pull_request(body),
+        "issues" => format_issues(body),
+        "push" => format_push(body),
+        "workflow_run" => format_workflow_run(body),
+        "release" => format_release(body),
+        _ => {
+            debug!("Unsupported GitHub webhook event: {}", event_type);
+            return vec![];
+        }
+    };
+
+    if content.is_empty() && metadata.get("embed_title").is_none() {
+        return vec![];
+    }
+
+    let mut messages = Vec::with_capacity(config.discord_channel_ids.len());
+    for channel_id in &config.discord_channel_ids {
+        let mut msg = OutboundMessage::new("discord", channel_id.clone(), content.clone());
+        if !metadata.is_empty() {
+            msg.metadata = metadata.clone();
+        }
+        messages.push(msg);
+    }
+    messages
+}
+
+fn format_pull_request(body: &[u8]) -> (String, HashMap<String, serde_json::Value>) {
+    let payload: PullRequestPayload = match serde_json::from_slice(body) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("Failed to parse pull_request payload: {}", e);
+            return (String::new(), HashMap::new());
+        }
+    };
+    let action = payload.action.as_deref().unwrap_or("unknown");
+    let repo = payload.repository.as_ref().and_then(|r| r.full_name.as_deref()).unwrap_or("unknown");
+    let pr = match payload.pull_request.as_ref() {
+        Some(p) => p,
+        None => return (String::new(), HashMap::new()),
+    };
+    let title = pr.title.as_deref().unwrap_or("(no title)");
+    let url = pr.html_url.clone();
+    let user = pr.user.as_ref().and_then(|u| u.login.as_deref()).unwrap_or("?");
+    let state = pr.state.as_deref().unwrap_or("");
+    let merged = pr.merged.unwrap_or(false);
+
+    let (action_label, color) = match (action, state, merged) {
+        ("opened", _, _) => ("PR opened", COLOR_PR_OPEN),
+        ("closed", _, true) => ("PR merged", COLOR_PR_MERGED),
+        ("closed", _, _) => ("PR closed", COLOR_PR_CLOSED),
+        ("reopened", _, _) => ("PR reopened", COLOR_PR_OPEN),
+        _ => ("PR updated", COLOR_CI_NEUTRAL),
+    };
+
+    let description = format!("**{}**\nBy **{}** · [#{}]({})", title, user, payload.number.unwrap_or(0), url.as_deref().unwrap_or(""));
+    let title_line = format!("{} · {}", repo, action_label);
+    let metadata = embed_metadata(title_line, description, url, color);
+    (String::new(), metadata)
+}
+
+fn format_issues(body: &[u8]) -> (String, HashMap<String, serde_json::Value>) {
+    let payload: IssuesPayload = match serde_json::from_slice(body) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("Failed to parse issues payload: {}", e);
+            return (String::new(), HashMap::new());
+        }
+    };
+    let action = payload.action.as_deref().unwrap_or("unknown");
+    let repo = payload.repository.as_ref().and_then(|r| r.full_name.as_deref()).unwrap_or("unknown");
+    let issue = match payload.issue.as_ref() {
+        Some(i) => i,
+        None => return (String::new(), HashMap::new()),
+    };
+    let title = issue.title.as_deref().unwrap_or("(no title)");
+    let url = issue.html_url.clone();
+    let user = issue.user.as_ref().and_then(|u| u.login.as_deref()).unwrap_or("?");
+
+    let action_label = match action {
+        "opened" => "Issue opened",
+        "closed" => "Issue closed",
+        "reopened" => "Issue reopened",
+        _ => "Issue updated",
+    };
+
+    let description = format!("**{}**\nBy **{}** · [#{}]({})", title, user, issue.number.unwrap_or(0), url.as_deref().unwrap_or(""));
+    let title_line = format!("{} · {}", repo, action_label);
+    let metadata = embed_metadata(title_line, description, url, COLOR_ISSUE);
+    (String::new(), metadata)
+}
+
+fn format_push(body: &[u8]) -> (String, HashMap<String, serde_json::Value>) {
+    let payload: PushPayload = match serde_json::from_slice(body) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("Failed to parse push payload: {}", e);
+            return (String::new(), HashMap::new());
+        }
+    };
+    let repo = payload.repository.as_ref().and_then(|r| r.full_name.as_deref()).unwrap_or("unknown");
+    let r#ref = payload.r#ref.as_deref().unwrap_or("").strip_prefix("refs/heads/").unwrap_or("");
+    let pusher = payload.pusher.as_ref().and_then(|p| p.name.as_deref()).unwrap_or("?");
+    let compare = payload.compare.clone();
+    let commits = payload.commits.as_deref().unwrap_or(&[]);
+    let count = commits.len();
+    let last_msg = commits.last().and_then(|c| c.message.as_deref()).unwrap_or("(no message)");
+    let first_line = last_msg.lines().next().unwrap_or(last_msg);
+
+    let title_line = format!("{} · Push to `{}`", repo, r#ref);
+    let description = format!("**{}** pushed {} commit(s)\n\n{}", pusher, count, first_line);
+    let metadata = embed_metadata(title_line, description, compare, COLOR_PUSH);
+    (String::new(), metadata)
+}
+
+fn format_workflow_run(body: &[u8]) -> (String, HashMap<String, serde_json::Value>) {
+    let payload: WorkflowRunPayload = match serde_json::from_slice(body) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("Failed to parse workflow_run payload: {}", e);
+            return (String::new(), HashMap::new());
+        }
+    };
+    let repo = payload.repository.as_ref().and_then(|r| r.full_name.as_deref()).unwrap_or("unknown");
+    let run = match payload.workflow_run.as_ref() {
+        Some(r) => r,
+        None => return (String::new(), HashMap::new()),
+    };
+    let name = run.name.as_deref().unwrap_or("Workflow");
+    let status = run.status.as_deref().unwrap_or("?");
+    let conclusion = run.conclusion.as_deref().unwrap_or("");
+    let url = run.html_url.clone();
+
+    let (color, conclusion_text) = match conclusion {
+        "success" => (COLOR_CI_SUCCESS, "Success"),
+        "failure" | "cancelled" => (COLOR_CI_FAILURE, conclusion),
+        _ => (COLOR_CI_NEUTRAL, if conclusion.is_empty() { status } else { conclusion }),
+    };
+
+    let title_line = format!("{} · CI {}", repo, conclusion_text);
+    let description = format!("**{}**\nStatus: {}", name, conclusion_text);
+    let metadata = embed_metadata(title_line, description, url, color);
+    (String::new(), metadata)
+}
+
+fn format_release(body: &[u8]) -> (String, HashMap<String, serde_json::Value>) {
+    let payload: ReleasePayload = match serde_json::from_slice(body) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("Failed to parse release payload: {}", e);
+            return (String::new(), HashMap::new());
+        }
+    };
+    let action = payload.action.as_deref().unwrap_or("published");
+    let repo = payload.repository.as_ref().and_then(|r| r.full_name.as_deref()).unwrap_or("unknown");
+    let release = match payload.release.as_ref() {
+        Some(r) => r,
+        None => return (String::new(), HashMap::new()),
+    };
+    let name = release.name.as_deref().or(release.tag_name.as_deref()).unwrap_or("Release");
+    let url = release.html_url.clone();
+    let author = release.author.as_ref().and_then(|a| a.login.as_deref()).unwrap_or("?");
+
+    let title_line = format!("{} · Release {}", repo, action);
+    let description = format!("**{}**\nBy **{}**", name, author);
+    let metadata = embed_metadata(title_line, description, url, COLOR_RELEASE);
+    (String::new(), metadata)
+}

--- a/core/src/webhooks/mod.rs
+++ b/core/src/webhooks/mod.rs
@@ -1,0 +1,5 @@
+//! Webhook receivers (e.g. GitHub → Discord notifications).
+
+pub mod github;
+
+pub use github::{build_discord_notifications, verify_signature};


### PR DESCRIPTION
## 📋 Summary

Adds **GitHub Webhook Notification Integration**: the gateway receives GitHub repo events (pull requests, issues, push, workflow_run, release) via a new HTTP endpoint and posts formatted Discord embeds to configured channels. This fulfills the “push GitHub events to Discord” workflow so teams see repo activity in the same Discord server where they use the mofaclaw bot.

## 🔗 Related Issues

Closes #28

Related to #9

---

## 🧠 Context

- **Issue #28** requested: receive GitHub webhooks, parse payloads, and send notifications to Discord with nice embeds, configurable channels, and event filtering.
- **Depends on #9**: Discord is already a channel for the mofaclaw agent; this feature reuses that channel to deliver webhook notifications so one bot serves both chat and GitHub notifications.
- Design: add an HTTP server (axum) to the gateway, one route `POST /webhooks/github`, signature verification, and formatters that produce outbound Discord messages (with embed metadata). The existing Discord channel consumes those and sends embeds when metadata is present.

---

## 🛠️ Changes

- **Config**
  - New `webhooks.github`: `enabled`, `secret`, `discord_channel_ids`, `events` (optional filter).
  - New `WebhooksConfig` and `GitHubWebhookConfig` in `core/src/config.rs`; root `Config` gains `webhooks`.
- **Core – webhooks**
  - New `core/src/webhooks/` with `github.rs`: payload types (pull_request, issues, push, workflow_run, release), `verify_signature` (HMAC-SHA256), `build_discord_notifications()` producing `OutboundMessage`s with embed metadata.
  - Dependencies: `hmac`, `sha2`, `hex` in `core/Cargo.toml`.
- **Core – Discord**
  - In `core/src/channels/discord/mod.rs`, outbound handler checks for `embed_title` / `embed_description` (and optional `embed_url`, `embed_color`) in message metadata and sends a Discord embed via `CreateMessage::new().embed(...)` instead of plain text.
- **CLI – HTTP server**
  - Axum server bound on `gateway.host:port` when running `mofaclaw gateway`.
  - `POST /webhooks/github`: reads `X-GitHub-Event` and `X-Hub-Signature-256`, verifies signature, calls `build_discord_notifications`, publishes each message to the bus.
  - New `WebhookState` (config + bus); CORS layer for webhook route.
  - Dependencies: `axum`, `tower`, `tower-http` in `cli/Cargo.toml`.
- **Docs**
  - `README.md`: full config example includes `webhooks.github`; “GitHub Webhook → Discord” section with link to setup guide.
  - New `docs/DISCORD_WEBHOOK_SETUP.md`: full setup (Discord bot, config, gateway, GitHub webhook, testing, troubleshooting, “Why mofaclaw?” workflow).

---

## 🧪 How you Tested

1. **Build**
   - `cargo build --workspace` and `cargo clippy --workspace` (addressed one `unused_mut` in webhooks).
  
<img width="537" height="94" alt="image" src="https://github.com/user-attachments/assets/7a635784-69ba-4ba1-9c59-b666250f2fb4" />

2. **Config**
   - Started gateway with `webhooks.github.enabled: true`, `discord_channel_ids` set, `secret` set; confirmed “Webhooks: listening on http://0.0.0.0:18790”.
3. **Webhook**
   - In GitHub repo: Settings → Webhooks → Add webhook → URL `http(s)://HOST:18790/webhooks/github`, content type `application/json`, same secret, selected events (pull_request, issues, push, workflow_run, release). Verified “Recent Deliveries” success.
4. **Notifications**
   - Triggered push, issue created, PR opened/merged; confirmed Discord channel received embeds (title, description, link, color) from the mofaclaw bot.
5. **Filtering**
   - Set `events: ["pull_request"]`; only PR events produced Discord messages.

---

## 📸 Screenshots / Logs (if applicable)

### Webhook message in Discord (after a GitHub action)

<img width="468" height="172" alt="image" src="https://github.com/user-attachments/assets/8c409f65-1369-4bf3-994b-0a03cba3abd8" />


---

## ⚠️ Breaking Changes

- [x] No breaking changes
- [ ] Breaking change (describe below)

Config is additive: new `webhooks` section with defaults (`enabled: false`, empty `discord_channel_ids`). Existing configs load unchanged.

---

## 🧹 Checklist

### Code Quality
- [x] Code follows Rust idioms and project conventions
- [x] `cargo fmt` run
- [x] `cargo clippy --workspace --all-features` passes locally

### Testing
- [ ] Tests added/updated
- [x] `cargo test --workspace --all-features` passes locally
- [ ] `cargo build --examples` (if examples are present)

### Documentation
- [x] Public APIs documented (webhook module, config fields)
- [x] README / docs updated (README + `docs/DISCORD_WEBHOOK_SETUP.md`)

### PR Hygiene
- [x] PR is small and focused (one logical change)
- [x] Branch is up to date with `main`
- [x] No unrelated commits
- [x] Commit messages explain **why**, not only **what**

---

## 🚀 Deployment Notes (if applicable)

- **Config:** Optional `webhooks.github` in `~/.mofaclaw/config.json`. If omitted, webhook endpoint returns 200 with “webhook not configured” and does nothing.
- **Reachability:** For GitHub to deliver webhooks, the gateway must be reachable at `http(s)://HOST:18790/webhooks/github` (e.g. public IP + open port, or tunnel such as ngrok/cloudflared).
- **Discord:** Bot must be in the server and have Send Messages + Embed Links in the channels listed in `discord_channel_ids`.

---

## 🧩 Additional Notes for Reviewers

- Signature verification: if `webhooks.github.secret` is empty, verification is skipped (convenient for local/dev; not recommended in production).
- Discord outbound: embed path is gated on presence of `embed_title` and `embed_description` in `OutboundMessage.metadata`; other outbound messages unchanged (plain/chunked text as before).
- Gateway now spawns the axum server in the background; it shares the same `Config` and `MessageBus` as the Discord channel so webhook handlers can publish to Discord via the existing bus.