### PR TITLE
docs: add Filesystem Sandbox documentation (RBAC)

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -416,6 +416,51 @@ Each variant carries context. For example, `ToolError::ExecutionFailed` includes
 ---
 
 ## The Workspace
+---
+
+## Security & Access Control (RBAC)
+
+mofaclaw includes a powerful Role-Based Access Control (RBAC) system that sandboxes the AI's capabilities. This protects your system from accidental damage or malicious prompt injections when using tools like shell execution or file system access.
+
+### Roles
+The agent's permissions are determined by your RBAC configuration: the global default comes from `rbac.default_role`, and individual channels can override it via `rbac.role_mappings` and `rbac.user_overrides` in `config.json`.
+- **Guest**: Highly restricted. Read-only access to specific folders. No shell commands.
+- **Member** (Default): Standard access. Can read/write to the workspace and run safe commands.
+- **Admin**: Extended access for managing the system.
+- **SuperAdmin**: Unlimited access (Bypasses all sandboxing).
+
+### 🛡️ Filesystem Sandbox (Path Whitelisting)
+When RBAC filesystem permissions are configured, mofaclaw can restrict which paths the AI may read or write.
+In that case, access is allowed only for paths matching the role's configured `path_whitelist`; if no such permissions are defined, filesystem access is not restricted by RBAC.
+
+Example configuration in `config.json`:
+```json
+"rbac": {
+  "permissions": {
+    "tools": {
+      "filesystem": {
+        "read": {
+          "min_role": "guest",
+          "path_whitelist": {
+            "guest": ["${workspace}/**"],
+            "member": ["${workspace}/**", "${home}/projects/**"]
+          }
+        },
+        "write": {
+          "min_role": "member",
+          "path_whitelist": {
+            "member": ["${workspace}/**"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+*Variables like `${workspace}` and `${home}` are automatically resolved.*
+
+---
+
 
 When you run `mofaclaw onboard`, it creates a workspace that acts as the agent's working environment:
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -416,51 +416,6 @@ Each variant carries context. For example, `ToolError::ExecutionFailed` includes
 ---
 
 ## The Workspace
----
-
-## Security & Access Control (RBAC)
-
-mofaclaw includes a powerful Role-Based Access Control (RBAC) system that sandboxes the AI's capabilities. This protects your system from accidental damage or malicious prompt injections when using tools like shell execution or file system access.
-
-### Roles
-The agent's permissions are determined by your RBAC configuration: the global default comes from `rbac.default_role`, and individual channels can override it via `rbac.role_mappings` and `rbac.user_overrides` in `config.json`.
-- **Guest**: Highly restricted. Read-only access to specific folders. No shell commands.
-- **Member** (Default): Standard access. Can read/write to the workspace and run safe commands.
-- **Admin**: Extended access for managing the system.
-- **SuperAdmin**: Unlimited access (Bypasses all sandboxing).
-
-### 🛡️ Filesystem Sandbox (Path Whitelisting)
-When RBAC filesystem permissions are configured, mofaclaw can restrict which paths the AI may read or write.
-In that case, access is allowed only for paths matching the role's configured `path_whitelist`; if no such permissions are defined, filesystem access is not restricted by RBAC.
-
-Example configuration in `config.json`:
-```json
-"rbac": {
-  "permissions": {
-    "tools": {
-      "filesystem": {
-        "read": {
-          "min_role": "guest",
-          "path_whitelist": {
-            "guest": ["${workspace}/**"],
-            "member": ["${workspace}/**", "${home}/projects/**"]
-          }
-        },
-        "write": {
-          "min_role": "member",
-          "path_whitelist": {
-            "member": ["${workspace}/**"]
-          }
-        }
-      }
-    }
-  }
-}
-```
-*Variables like `${workspace}` and `${home}` are automatically resolved.*
-
----
-
 
 When you run `mofaclaw onboard`, it creates a workspace that acts as the agent's working environment:
 
@@ -493,6 +448,50 @@ When you run `mofaclaw onboard`, it creates a workspace that acts as the agent's
 - **`TOOLS.md`** — Documents all tools from the agent's perspective (what each tool does, its parameters)
 - **`HEARTBEAT.md`** — Tasks the agent checks every 30 minutes (add checklist items here)
 - **`memory/MEMORY.md`** — Persistent facts the agent remembers across sessions
+
+---
+
+## Security & Access Control (RBAC)
+
+mofaclaw includes a powerful Role-Based Access Control (RBAC) system that sandboxes the AI's capabilities. This protects your system from accidental damage or malicious prompt injections when using tools like shell execution or file system access.
+
+### Roles
+The agent's permissions are determined by your RBAC configuration: the global default comes from `rbac.default_role`, and individual channels can override it via their entries under `rbac.role_mappings` in `config.json` (for example, `rbac.role_mappings.discord.user_overrides` for per-user overrides on Discord). The roles below describe **typical recommended configurations**; the actual behavior depends on your `rbac.permissions.*` settings (for example, shell access via `rbac.permissions.tools.shell.safe_commands.min_role`).
+- **Guest**: Highly restricted. Typically configured with read-only access to specific folders and no shell command permissions, unless `rbac.permissions.tools.shell.safe_commands.min_role` is set to allow it.
+- **Member**: Standard access. Often configured as the default role. Can usually read/write to the workspace and run safe commands, depending on your RBAC permission settings.
+- **Admin**: Extended access for managing the system.
+- **SuperAdmin**: Highest-privilege role. Bypasses shell command sandboxing, but is still subject to filesystem path whitelist/blacklist rules unless explicitly allowed there.
+
+### 🛡️ Filesystem Sandbox (Path Whitelisting)
+When RBAC filesystem permissions are configured, mofaclaw can restrict which paths the AI may read or write.
+In that case, for all roles (including `superadmin`), access is allowed only for paths matching the role's configured `path_whitelist`; if no such permissions are defined, filesystem access is not restricted by RBAC.
+
+Example configuration in `config.json`:
+```json
+"rbac": {
+  "enabled": true,
+  "permissions": {
+    "tools": {
+      "filesystem": {
+        "read": {
+          "min_role": "guest",
+          "path_whitelist": {
+            "guest": ["${workspace}/**"],
+            "member": ["${workspace}/**", "${home}/projects/**"]
+          }
+        },
+        "write": {
+          "min_role": "member",
+          "path_whitelist": {
+            "member": ["${workspace}/**"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+*Variables like `${workspace}` and `${home}` are automatically resolved.*
 
 ---
 

--- a/TUTORIAL_CN.md
+++ b/TUTORIAL_CN.md
@@ -416,6 +416,50 @@ pub enum MofaclawError {
 ---
 
 ## 工作区
+---
+
+## 安全与访问控制 (RBAC)
+
+mofaclaw 包含一个强大的基于角色的访问控制 (RBAC) 系统，可以为 AI 的能力提供沙箱环境。这能够在 AI 使用执行 Shell 命令或访问文件系统等工具时，保护您的系统免受意外损坏或恶意提示词注入的攻击。
+
+### 角色 (Roles)
+代理的权限由 `config.json` 中 `rbac.default_role` 指定的默认角色，以及各渠道通过 `rbac.role_mappings` / `user_overrides` 解析得到的实际角色共同决定。
+- **Guest (访客)**: 权限严格受限。仅对特定文件夹拥有只读访问权限。无法执行 Shell 命令。
+- **Member (成员)** (默认): 标准权限。可以读写工作区，并能运行安全的已列入白名单的命令。
+- **Admin (管理员)**: 拥有管理系统的扩展权限。
+- **SuperAdmin (超级管理员)**: 无限制访问权限（绕过所有沙箱限制）。
+
+### 🛡️ 文件系统沙箱 (路径白名单)
+当配置文件系统权限时，mofaclaw 会限制 AI 可以读写哪些路径。在这种情况下，只有匹配角色 `path_whitelist`（路径白名单）的路径才被允许访问；如果未配置相关权限，则文件系统访问不受 RBAC 限制。
+
+`config.json` 中的配置示例：
+```json
+"rbac": {
+  "permissions": {
+    "tools": {
+      "filesystem": {
+        "read": {
+          "min_role": "guest",
+          "path_whitelist": {
+            "guest": ["${workspace}/**"],
+            "member": ["${workspace}/**", "${home}/projects/**"]
+          }
+        },
+        "write": {
+          "min_role": "member",
+          "path_whitelist": {
+            "member": ["${workspace}/**"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+*类似 `${workspace}` 和 `${home}` 的变量会被自动解析。*
+
+---
+
 
 运行 `mofaclaw onboard` 后，会创建一个作为代理工作环境的工作区：
 

--- a/TUTORIAL_CN.md
+++ b/TUTORIAL_CN.md
@@ -416,50 +416,6 @@ pub enum MofaclawError {
 ---
 
 ## 工作区
----
-
-## 安全与访问控制 (RBAC)
-
-mofaclaw 包含一个强大的基于角色的访问控制 (RBAC) 系统，可以为 AI 的能力提供沙箱环境。这能够在 AI 使用执行 Shell 命令或访问文件系统等工具时，保护您的系统免受意外损坏或恶意提示词注入的攻击。
-
-### 角色 (Roles)
-代理的权限由 `config.json` 中 `rbac.default_role` 指定的默认角色，以及各渠道通过 `rbac.role_mappings` / `user_overrides` 解析得到的实际角色共同决定。
-- **Guest (访客)**: 权限严格受限。仅对特定文件夹拥有只读访问权限。无法执行 Shell 命令。
-- **Member (成员)** (默认): 标准权限。可以读写工作区，并能运行安全的已列入白名单的命令。
-- **Admin (管理员)**: 拥有管理系统的扩展权限。
-- **SuperAdmin (超级管理员)**: 无限制访问权限（绕过所有沙箱限制）。
-
-### 🛡️ 文件系统沙箱 (路径白名单)
-当配置文件系统权限时，mofaclaw 会限制 AI 可以读写哪些路径。在这种情况下，只有匹配角色 `path_whitelist`（路径白名单）的路径才被允许访问；如果未配置相关权限，则文件系统访问不受 RBAC 限制。
-
-`config.json` 中的配置示例：
-```json
-"rbac": {
-  "permissions": {
-    "tools": {
-      "filesystem": {
-        "read": {
-          "min_role": "guest",
-          "path_whitelist": {
-            "guest": ["${workspace}/**"],
-            "member": ["${workspace}/**", "${home}/projects/**"]
-          }
-        },
-        "write": {
-          "min_role": "member",
-          "path_whitelist": {
-            "member": ["${workspace}/**"]
-          }
-        }
-      }
-    }
-  }
-}
-```
-*类似 `${workspace}` 和 `${home}` 的变量会被自动解析。*
-
----
-
 
 运行 `mofaclaw onboard` 后，会创建一个作为代理工作环境的工作区：
 
@@ -492,6 +448,49 @@ mofaclaw 包含一个强大的基于角色的访问控制 (RBAC) 系统，可以
 - **`TOOLS.md`** — 从代理角度记录所有工具（每个工具的功能、参数）
 - **`HEARTBEAT.md`** — 代理每 30 分钟检查的任务（在此添加任务清单）
 - **`memory/MEMORY.md`** — 代理跨会话记住的持久化事实
+
+---
+
+## 安全与访问控制 (RBAC)
+
+mofaclaw 包含一个强大的基于角色的访问控制 (RBAC) 系统，可以为 AI 的能力提供沙箱环境。这能够在 AI 使用执行 Shell 命令或访问文件系统等工具时，保护您的系统免受意外损坏或恶意提示词注入的攻击。
+
+### 角色 (Roles)
+代理的最终权限**完全由配置决定**：包括 `config.json` 中 `rbac.default_role` 指定的默认角色（当前实现的内置默认值为 `"guest"`），以及各渠道通过 `rbac.role_mappings.<channel>.user_overrides`（例如 `rbac.role_mappings.discord.user_overrides`）解析得到的实际角色。
+- **Guest (访客)**: 权限严格受限。通常仅对特定文件夹拥有只读访问权限。是否可以执行 Shell 命令等高危操作，取决于 `rbac.permissions.tools.shell` 下各操作的 `min_role` / `path_whitelist` 等配置，而不是角色“天生”禁止。
+- **Member (成员)**: 标准权限。可以读写工作区，并能运行配置中允许、已列入白名单的命令。常用于日常开发或受信任的团队成员，如需将默认角色设为 Member，应显式在 `rbac.default_role` 中配置。
+- **Admin (管理员)**: 拥有管理系统的扩展权限。
+- **SuperAdmin (超级管理员)**: 最高权限角色。可访问所有已在 RBAC 中授权的工具与路径；但如果启用了文件系统沙箱，仍需在相应的 `path_whitelist` / `path_blacklist` 中显式为 `superadmin` 配置规则，否则访问也会被拒绝。
+
+### 🛡️ 文件系统沙箱 (路径白名单)
+当配置文件系统权限时，mofaclaw 会限制 AI 可以读写哪些路径。在这种情况下，所有角色（包括 SuperAdmin）都只允许访问与其角色匹配的 `path_whitelist`（路径白名单）中的路径；如果未配置相关权限，则文件系统访问不受 RBAC 限制。若希望 SuperAdmin 在文件系统上拥有几乎无限制的访问能力，应在相应权限项下为 `superadmin` 配置足够宽泛的路径模式（例如 `"${workspace}/**"`、`"${home}/**"` 等），而不是假定其会自动绕过沙箱。
+
+`config.json` 中的配置示例：
+```json
+"rbac": {
+  "enabled": true,
+  "permissions": {
+    "tools": {
+      "filesystem": {
+        "read": {
+          "min_role": "guest",
+          "path_whitelist": {
+            "guest": ["${workspace}/**"],
+            "member": ["${workspace}/**", "${home}/projects/**"]
+          }
+        },
+        "write": {
+          "min_role": "member",
+          "path_whitelist": {
+            "member": ["${workspace}/**"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+*类似 `${workspace}` 和 `${home}` 的变量会被自动解析。*
 
 ---
 


### PR DESCRIPTION
## Description
This PR addresses the lack of documentation for the recently implemented **Filesystem Sandbox** feature within the Role-Based Access Control (RBAC) system. 

While the core functionality was already merged into `core/src/rbac`, users had no instructions on how to configure or use the `path_whitelist` to secure their agent's file system access. This PR adds comprehensive explanations and configuration examples to both the English (`TUTORIAL.md`) and Chinese (`TUTORIAL_CN.md`) tutorials.

### Changes Made
- Documented how `rbac.default_role` and `rbac.role_mappings` define access levels (Guest, Member, Admin, SuperAdmin).
- Added JSON schema examples showing how to properly configure file read/write permissions under `permissions.tools.filesystem`.
- Clarified that file system limits are strictly enforced when the RBAC `path_whitelist` is configured.

**Resolves:** Closes #66
