### PR TITLE
feat(skill): add PR review skill (#88)

### DIFF
--- a/core/src/agent/context.rs
+++ b/core/src/agent/context.rs
@@ -331,3 +331,46 @@ Read the skill's SKILL.md file using the `read_file` tool to learn how to use it
         &self.skills
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::default_config;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_skills_summary_includes_pr_review() {
+        let temp = tempdir().expect("tempdir");
+        let mut config = default_config();
+        config.agents.defaults.workspace = temp.path().display().to_string();
+
+        let context = ContextBuilder::new(&config);
+        let prompt = context
+            .build_system_prompt(None)
+            .await
+            .expect("system prompt");
+
+        assert!(
+            prompt.contains("pr-review"),
+            "prompt did not include pr-review skill summary"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_requested_pr_review_skill_is_loaded() {
+        let temp = tempdir().expect("tempdir");
+        let mut config = default_config();
+        config.agents.defaults.workspace = temp.path().display().to_string();
+
+        let context = ContextBuilder::new(&config);
+        let requested = vec!["pr-review".to_string()];
+        let prompt = context
+            .build_system_prompt(Some(&requested))
+            .await
+            .expect("system prompt");
+
+        assert!(prompt.contains("# Requested Skills"));
+        assert!(prompt.contains("# PR Review Skill"));
+        assert!(prompt.contains("PR Template Compliance"));
+    }
+}

--- a/core/src/session/mod.rs
+++ b/core/src/session/mod.rs
@@ -93,7 +93,8 @@ impl SessionManager {
 
     /// Get an existing session or create a new one (delegates to mofa)
     pub async fn get_or_create(&self, key: impl Into<String>) -> Session {
-        self.inner.get_or_create(&key.into()).await
+        let key = key.into();
+        self.inner.get_or_create(&storage_key(&key)).await
     }
 
     /// Load a session from disk
@@ -127,7 +128,7 @@ impl SessionManager {
     /// Delete a session (delegates to mofa)
     pub async fn delete(&self, key: &str) -> Result<bool> {
         self.inner
-            .delete(key)
+            .delete(&storage_key(key))
             .await
             .map_err(|e| crate::error::SessionError::LoadFailed(e.to_string()).into())
     }
@@ -177,8 +178,7 @@ impl SessionManager {
 
     /// Get the file path for a session
     fn get_session_path(&self, key: &str) -> PathBuf {
-        let safe_key = safe_filename(&key.replace(':', "_"));
-        self.sessions_dir.join(format!("{}.jsonl", safe_key))
+        self.sessions_dir.join(format!("{}.jsonl", storage_key(key)))
     }
 
     /// Get the inner mofa SessionManager (for advanced usage)
@@ -198,6 +198,10 @@ fn safe_filename(name: &str) -> String {
             }
         })
         .collect()
+}
+
+fn storage_key(key: &str) -> String {
+    safe_filename(&key.replace(':', "_"))
 }
 
 // ============================================================================
@@ -306,6 +310,12 @@ mod tests {
     }
 
     #[test]
+    fn test_storage_key_replaces_windows_unsafe_separators() {
+        assert_eq!(storage_key("cli:default"), "cli_default");
+        assert_eq!(storage_key("discord:general/chat"), "discord_general_chat");
+    }
+
+    #[test]
     fn test_message_conversion() {
         // Test Message -> SessionMessage
         let msg = Message::user("Hello world");
@@ -354,13 +364,13 @@ mod tests {
         let manager = SessionManager::with_sessions_dir(temp_dir.path().to_path_buf());
 
         let session = manager.get_or_create("test:session").await;
-        assert_eq!(session.key, "test:session");
+        assert_eq!(session.key, "test_session");
 
         manager.save(&session).await.unwrap();
 
         // Reload
         let loaded = manager.get_or_create("test:session").await;
-        assert_eq!(loaded.key, "test:session");
+        assert_eq!(loaded.key, "test_session");
     }
 
     #[tokio::test]

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,6 +6,7 @@ This directory contains the builtin skills for mofaclaw. These skills are automa
 
 - **weather** - Get current weather and forecasts using wttr.in (no API key required)
 - **github** - Interact with GitHub using the `gh` CLI
+- **pr-review** - Review pull requests with structured checks for scope, security, tests, CI, and reviewer comments
 - **summarize** - Summarize or extract text/transcripts from URLs, podcasts, and local files
 - **tmux** - Remote-control tmux sessions for interactive CLIs
 - **skill-creator** - Meta-skill for creating new skills

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,0 +1,351 @@
+---
+name: pr-review
+description: "Analyze pull requests and provide structured code review suggestions. Use when the user asks to review a PR, check a PR, analyze pull request changes, inspect CI status, summarize review findings, verify PR template compliance, or generate review comments."
+metadata:
+  mofaclaw:
+    emoji: "🔍"
+    requires:
+      bins: ["gh", "git"]
+    install:
+      - id: brew
+        kind: brew
+        formula: gh
+        bins: ["gh"]
+        label: "Install GitHub CLI (brew)"
+      - id: apt
+        kind: apt
+        package: gh
+        bins: ["gh"]
+        label: "Install GitHub CLI (apt)"
+---
+
+# PR Review Skill
+
+Use the `gh` CLI to analyze pull requests and provide structured code review suggestions. Focus on reviewer assistance, not autopilot approval. Prefer concrete findings, reproducible commands, and links back to the exact failing checks or changed code.
+
+When possible, collect facts in this order:
+1. PR metadata and body
+2. Changed-file summary
+3. Targeted diff inspection
+4. CI status and logs
+5. Final review comment
+
+## When to Use (Trigger Phrases)
+
+Use this skill immediately when the user asks any of:
+- "review this PR"
+- "review pr"
+- "check this pr"
+- "pr review for"
+- "analyze pull request"
+- "what changed in this PR"
+- "review code changes"
+- "check CI status on PR"
+- "generate review comment for PR"
+- "is this PR ready to merge"
+- "summarize the review findings on this PR"
+
+## Workflow
+
+### Step 1: PR Overview
+
+Fetch PR metadata and summary. Start with structured JSON before reading raw patch output:
+
+```bash
+# Get PR details with files, additions, deletions
+gh pr view <PR_NUMBER> --repo <OWNER/REPO> --json title,body,author,state,baseRefName,headRefName,additions,deletions,changedFiles,files
+
+# Example for mofaclaw repo
+gh pr view 78 --repo mofa-org/mofaclaw --json title,body,author,baseRefName,headRefName,files,additions,deletions,changedFiles
+
+# Get commit messages for change intent and breaking-change clues
+gh api repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/commits --jq '.[].commit.message'
+```
+
+Review checklist:
+- Confirm title, author, base branch, and head branch make sense.
+- Summarize scope from changed files before diving into patch details.
+- Note whether the PR is unusually large and may need splitting.
+
+### Step 1.5: PR Template Compliance
+
+Check whether the PR description follows the repository template or at least covers expected review sections:
+
+```bash
+gh pr view <PR_NUMBER> --repo <OWNER/REPO> --json body --jq .body
+```
+
+Look for expected sections such as:
+- summary or motivation
+- linked issue
+- testing notes
+- rollout or risk notes when applicable
+
+If the body is empty or missing key sections, call it out as a reviewer suggestion rather than inventing compliance.
+
+### Step 2: Code Change Analysis
+
+Analyze changed files by type:
+
+```bash
+# List all changed files
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> --name-only
+
+# Get additions/deletions summary (use --json with pr view)
+gh pr view <PR_NUMBER> --repo <OWNER/REPO> --json additions,deletions,changedFiles
+
+# Get detailed file changes with patch (Unix/Mac)
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> --patch | head -100
+
+# Get detailed file changes with patch (PowerShell)
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> --patch | Select-Object -First 100
+
+# Inspect one risky file more closely
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> --patch -- <PATH>
+```
+
+**File type categorization:**
+- `src/` - Source code
+- `test/` or `tests/` - Test files
+- `config/` or `.github/` - Configuration
+- `docs/` or `*.md` - Documentation
+
+**Flag large diffs:**
+- >10 files or >500 lines: Requires careful review
+- >20 files or >1000 lines: Consider splitting
+
+**Breaking-change checks:**
+- Compare changed public APIs, config schema, CLI flags, env vars, and default behavior.
+- Read commit messages for words like `breaking`, `rename`, `remove`, `deprecate`, or `migrate`.
+- Treat changes in `core/src/lib.rs`, public exports, config structs, API routes, and external command behavior as higher risk.
+- If a breaking change is likely, verify the PR body documents migration impact.
+
+### Step 3: Security Checks
+
+Check for sensitive file changes and potential vulnerabilities:
+
+```bash
+# Check for sensitive files (Unix/Mac)
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> --name-only | grep -iE '(password|secret|key|token|credentials|\.env|config\.json)'
+
+# Check for sensitive files (Windows)
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> --name-only | findstr /i "password secret key token credentials .env config.json"
+
+# Check for potential injection patterns in diff (Unix/Mac)
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> | grep -iE '(exec\(|system\(|eval\(|shell_exec\(|subprocess\()'
+
+# Check for potential injection patterns (Windows)
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> | findstr /i "exec( system( eval( shell_exec( subprocess("
+
+# Check for SQL injection patterns (Unix/Mac)
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> | grep -iE '(SELECT|INSERT|UPDATE|DELETE).*\+.*'
+
+# Check for changed workflow, deployment, or secret-related files
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> --name-only | findstr /i ".github/workflows docker compose .env secret token key"
+```
+
+**Security checklist:**
+- [ ] No credentials/secrets exposed
+- [ ] No hardcoded API keys or tokens
+- [ ] Input validation present
+- [ ] No dangerous functions (exec, eval, system)
+- [ ] No SQL injection vulnerabilities
+- [ ] No path traversal issues
+- [ ] Dependencies are secure
+
+### Step 4: Quality Suggestions
+
+Check for test coverage and documentation:
+
+```bash
+# Get list of changed source files (Unix/Mac)
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> --name-only | grep -E '^core/|^src/|^lib/'
+
+# Get list of changed source files (Windows)
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> --name-only | findstr "core/ src/ lib/"
+
+# Check if corresponding tests exist
+# For each .rs file, check if test_*.rs or *_test.rs exists
+
+# Check for documentation changes (Unix/Mac)
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> --name-only | grep -E '\.md$|docs/'
+
+# Check for documentation changes (Windows)
+gh pr diff <PR_NUMBER> --repo <OWNER/REPO> --name-only | findstr /i ".md docs/"
+```
+
+**Quality checklist:**
+- [ ] Modified source files have corresponding tests
+- [ ] Public APIs are documented
+- [ ] Breaking changes are documented
+- [ ] Code follows project style guidelines
+
+Reviewer guidance:
+- Prefer concrete missing-test observations over generic "needs more tests."
+- If public exports or config change, check for docs, examples, or migration notes.
+- When a file is risky but hard to test, ask for manual verification steps in the PR body.
+
+### Step 5: CI Status Check
+
+Verify CI/CD pipeline status:
+
+```bash
+# Check CI status
+gh pr checks <PR_NUMBER> --repo <OWNER/REPO>
+
+# Get detailed status in JSON
+gh pr view <PR_NUMBER> --repo <OWNER/REPO> --json statusCheckRollup
+
+# List recent runs tied to the PR branch
+gh run list --repo <OWNER/REPO> --branch <HEAD_BRANCH> --limit 10
+
+# Inspect a specific failed run
+gh run view <RUN_ID> --repo <OWNER/REPO>
+
+# Show logs for only failed steps
+gh run view <RUN_ID> --repo <OWNER/REPO> --log-failed
+```
+
+**CI checklist:**
+- [ ] All CI checks pass
+- [ ] No failed checks
+- [ ] Required checks are included
+
+CI review guidance:
+- Summarize failed checks by name, status, and what stage failed.
+- Include the `gh run view` URL or the Actions URL when reporting failures.
+- If all checks pass, say so briefly instead of over-explaining.
+- If checks are missing, state that clearly instead of assuming they passed.
+
+### Step 6: Review Comment Generation
+
+Generate structured review comments based on findings.
+
+Preferred output order:
+1. Blocking concerns
+2. Medium-risk suggestions
+3. Nits
+4. Short summary / recommendation
+
+Do not pad the review with generic praise if there are actionable issues.
+
+Minimum review output:
+- PR scope summary
+- File/risk summary
+- CI summary
+- Findings grouped as blocking, suggestions, and nits
+- Explicit recommendation: approve, comment, or request changes
+
+## Example Commands (Tested on mofaclaw)
+
+### Example 1: Large PR Analysis (PR #78)
+
+```bash
+# PR Overview
+gh pr view 78 --repo mofa-org/mofaclaw --json title,body,author,files,additions,deletions,changedFiles
+# Result: 755 additions, 4 deletions, 5 files changed
+
+# List changed files
+gh pr diff 78 --repo mofa-org/mofaclaw --name-only
+# Result: core/src/agent/loop_.rs, core/src/error.rs, core/src/lib.rs, core/src/tools/mod.rs, core/src/tools/permissions.rs
+
+# Check CI status
+gh pr checks 78 --repo mofa-org/mofaclaw
+
+# Check commit messages
+gh api repos/mofa-org/mofaclaw/pulls/78/commits --jq '.[].commit.message'
+```
+
+### Example 2: Small Documentation PR (PR #89)
+
+```bash
+# PR Overview
+gh pr view 89 --repo mofa-org/mofaclaw --json title,body,author,files,additions,deletions,changedFiles
+# Result: 32 additions, 1 deletion, 2 files changed
+
+# List changed files
+gh pr diff 89 --repo mofa-org/mofaclaw --name-only
+# Result: TUTORIAL.md, TUTORIAL_CN.md
+
+# Check CI status
+gh pr checks 89 --repo mofa-org/mofaclaw
+```
+
+### Example 3: Review CI Failure Details
+
+```bash
+# Find branch name first
+gh pr view 78 --repo mofa-org/mofaclaw --json headRefName --jq .headRefName
+
+# Find recent runs for that branch
+gh run list --repo mofa-org/mofaclaw --branch feat/permission-based-tool-registry --limit 5
+
+# View one run in detail
+gh run view <RUN_ID> --repo mofa-org/mofaclaw
+```
+
+## Review Comment Template
+
+Use this template for structured review comments:
+
+```markdown
+## Code Review Summary
+
+### PR Overview
+- **Title:** <PR title>
+- **Author:** <author>
+- **Files Changed:** <count> files, <additions> additions, <deletions> deletions
+- **CI Status:** ✅ Passing / ❌ Failing
+
+### Findings
+
+#### ✅ Things Look Good
+- <positive observation 1>
+- <positive observation 2>
+
+#### 🔧 Suggestions
+- <suggestion 1>
+- <suggestion 2>
+
+#### ⚠️ Concerns (Blocking)
+- <blocking issue 1>
+- <blocking issue 2>
+
+#### 📝 Nits
+- <minor issue 1>
+- <minor issue 2>
+
+### Security Check
+- [ ] No credentials exposed
+- [ ] Input validation present
+- [ ] No dangerous functions
+- [ ] Dependencies secure
+
+### Quality Check
+- [ ] Tests included
+- [ ] Documentation updated
+- [ ] Breaking changes documented
+
+---
+
+**Recommendation:** ✅ Approve / 🛡️ Request Changes / 💬 Comment
+```
+
+## Important Notes
+
+- Focus on assisting reviewers, not replacing them
+- Provide actionable suggestions, not just observations
+- Include escalation paths for security concerns
+- Consider rate limits when fetching large PRs
+- Always verify commands work as expected before including in output
+- Test against real PRs in the repository before finalizing review
+- If you did not inspect CI logs, say that explicitly instead of implying you did
+- If you infer a breaking change, label it as an inference and cite the changed surface
+
+## Error Handling
+
+If commands fail:
+- Check if PR number is valid
+- Verify repository exists and is accessible
+- Ensure `gh` is authenticated (`gh auth status`)
+- For large PRs, consider fetching just the summary first


### PR DESCRIPTION
## Summary

Add a new builtin PR review skill at `skills/pr-review/SKILL.md` that helps reviewers inspect pull requests with a structured workflow covering:

- PR overview and template compliance
- code change analysis
- security checks
- quality suggestions
- CI status checks
- review comment generation

This closes issue #88.

---

## What Changed

- Added `skills/pr-review/SKILL.md`
  - YAML frontmatter with metadata and required binaries
  - trigger phrases for PR review requests
  - step-by-step review workflow
  - Windows and Unix/Mac command variants
  - security / quality / CI checklists
  - structured review comment template
  - examples based on real mofaclaw PRs

- Updated `skills/README.md`
  - added `pr-review` to the builtin skills index

- Added prompt-loading coverage in `core/src/agent/context.rs`
  - verifies `pr-review` appears in the skills summary
  - verifies the requested skill body is loaded into context

- Fixed Windows local-testing blocker in `core/src/session/mod.rs`
  - sanitize session storage keys before they reach the underlying JSONL session store
  - this prevents Windows path failures for keys like `cli:default`

---



## Tests  Verification
![pr1](https://github.com/user-attachments/assets/3daae81d-020c-4ac0-af63-d4966595f500)


### 1. Direct command verification against real mofaclaw PRs

All core commands documented by the skill were tested locally with `gh` against real PRs in `mofa-org/mofaclaw`.

#### PR #78 - feature PR

Commands tested:

```bash
gh pr view 78 --repo mofa-org/mofaclaw --json title,body,author,files,additions,deletions,changedFiles
gh pr diff 78 --repo mofa-org/mofaclaw --name-only
gh pr checks 78 --repo mofa-org/mofaclaw
gh api repos/mofa-org/mofaclaw/pulls/78/commits --jq '.[].commit.message'
gh run list --repo mofa-org/mofaclaw --branch feat/permission-based-tool-registry --limit 3
```

Verified results:

- PR metadata returned successfully
- changed files returned successfully
- CI checks returned successfully
- commit history returned successfully
- Actions runs returned successfully

Observed CI summary for PR #78:

- Lint: pass
- Test (macos-latest): pass
- Test (ubuntu-latest): pass
- Test (windows-latest): pass
- rbac-tests: pass

#### PR #89 - docs PR

Commands tested:

```bash
gh pr view 89 --repo mofa-org/mofaclaw --json title,body,author,files,additions,deletions,changedFiles
gh pr diff 89 --repo mofa-org/mofaclaw --name-only
gh pr checks 89 --repo mofa-org/mofaclaw
```

Verified results:

- docs-only PR metadata returned successfully
- changed file listing returned successfully
- CI checks returned successfully

#### PR #80 - medium feature PR

Commands tested:

```bash
gh pr view 80 --repo mofa-org/mofaclaw --json title,body,author,files,additions,deletions,changedFiles
gh pr checks 80 --repo mofa-org/mofaclaw
```

Verified results:

- PR metadata returned successfully
- CI checks returned successfully

#### PRs #3 and #4 - older PRs with no checks

Commands tested:

```bash
gh pr view 3 --repo mofa-org/mofaclaw --json title,body,author,state,baseRefName,headRefName,additions,deletions,changedFiles,files
gh pr checks 3 --repo mofa-org/mofaclaw
gh pr diff 3 --repo mofa-org/mofaclaw --name-only

gh pr view 4 --repo mofa-org/mofaclaw --json title,body,author,state,baseRefName,headRefName,additions,deletions,changedFiles,files
gh pr checks 4 --repo mofa-org/mofaclaw
gh pr diff 4 --repo mofa-org/mofaclaw --name-only
```

Verified results:

- metadata and changed file listing worked
- `gh pr checks` correctly reported no checks for those older branches
- this validated the skill guidance that missing checks should be stated explicitly rather than assumed to be passing

### 2. End-to-end local mofaclaw verification

After fixing the Windows session-key issue, the skill was also exercised through a real local mofaclaw CLI run, not just raw `gh` commands.

Local setup used for verification:

- workspace moved to `D:\mofaclaw-workspace`
- Cargo target dir moved to `D:\cargo-targets\mofaclaw`
- a locally configured LLM provider was used for end-to-end agent verification; provider choice was only for local testing and is not part of this PR

Command used:

```bash
cargo run --quiet -- agent -s upstream-pr-test -m "Review PR #78 in mofa-org/mofaclaw using the pr-review skill. Do not use my fork. Check scope, security, tests, and CI."
```

Verified result:

- mofaclaw discovered `pr-review`
- the agent produced a structured review using real PR data from `mofa-org/mofaclaw`
- the output included PR overview, changed files, CI status, security checks, quality suggestions, and a recommendation

### 3. Automated verification

Rust tests run locally:

```bash
cargo test -p mofaclaw-core test_skills_summary_includes_pr_review -- --nocapture
cargo test -p mofaclaw-core test_requested_pr_review_skill_is_loaded -- --nocapture
```

Verified results:

- `test_skills_summary_includes_pr_review` passed
- `test_requested_pr_review_skill_is_loaded` passed

---

## Acceptance Criteria

- [x] `SKILL.md` created with proper YAML frontmatter
- [x] Skill triggers on phrases like "review pr", "check this pr", "pr review for"
- [x] Clear workflow for analyzing PRs step-by-step
- [x] Security checklist included
- [x] Template for review comments
- [x] Examples for different PR sizes/types
- [x] Tested against real PRs in mofaclaw
- [x] Human-reviewed and locally verified before merge

---

## Notes

- The skill intentionally assists reviewers rather than auto-approving PRs.
- Examples and commands were validated on Windows and use Windows-safe alternatives where needed (`findstr`, PowerShell examples).
- The local agent test used the upstream repo `mofa-org/mofaclaw` explicitly because the local git clone had a fork remote as `origin`.

---

![pr2](https://github.com/user-attachments/assets/1cfaddcc-9d70-4e3f-88fc-b15f63acda39)
